### PR TITLE
users without a VO should not get paths with VO variables

### DIFF
--- a/files/vscprompt.sh
+++ b/files/vscprompt.sh
@@ -17,19 +17,20 @@ fixpathvsc(){
     # convert canonical paths to environment variable
     if [[ $path =~ ^"$VSC_HOME"(.*)$ ]]; then
         path=\$VSC_HOME${BASH_REMATCH[1]}
-    elif [[ $path =~ ^"$VSC_DATA_VO_USER"(.*)$ ]]; then
+    elif [ "x$VSC_DATA_VO_USER" != "x" ] && [[ $path =~ ^"$VSC_DATA_VO_USER"(.*)$ ]]; then
         path=\$VSC_DATA_VO_USER${BASH_REMATCH[1]}
-    elif [[ $path =~ ^"$VSC_DATA_VO"(.*)$ ]]; then
+    elif [ "x$VSC_DATA_VO" != "x" ] && [[ $path =~ ^"$VSC_DATA_VO"(.*)$ ]]; then
         path=\$VSC_DATA_VO${BASH_REMATCH[1]}
     elif [[ $path =~ ^"$VSC_DATA"(.*)$ ]]; then
         path=\$VSC_DATA${BASH_REMATCH[1]}
-    elif [[ $path =~ ^"$VSC_SCRATCH_VO_USER"(.*)$ ]]; then
+    elif [ "x$VSC_SCRATCH_VO_USER" != "x" ] && [[ $path =~ ^"$VSC_SCRATCH_VO_USER"(.*)$ ]]; then
+        # personal scratch might be located inside a generic VO
         if [ $VSC_SCRATCH_VO_USER == $VSC_SCRATCH ];then
             path=\$VSC_SCRATCH${BASH_REMATCH[1]}
         else
             path=\$VSC_SCRATCH_VO_USER${BASH_REMATCH[1]}
         fi
-    elif [[ $path =~ ^"$VSC_SCRATCH_VO"(.*)$ ]]; then
+    elif [ "x$VSC_SCRATCH_VO" != "x" ] && [[ $path =~ ^"$VSC_SCRATCH_VO"(.*)$ ]]; then
         path=\$VSC_SCRATCH_VO${BASH_REMATCH[1]}
     elif [[ $path =~ ^"$VSC_SCRATCH"(.*)$ ]]; then
         path=\$VSC_SCRATCH${BASH_REMATCH[1]}

--- a/files/vscprompt.sh
+++ b/files/vscprompt.sh
@@ -17,20 +17,20 @@ fixpathvsc(){
     # convert canonical paths to environment variable
     if [[ $path =~ ^"$VSC_HOME"(.*)$ ]]; then
         path=\$VSC_HOME${BASH_REMATCH[1]}
-    elif [ "x$VSC_DATA_VO_USER" != "x" ] && [[ $path =~ ^"$VSC_DATA_VO_USER"(.*)$ ]]; then
+    elif [ -n "$VSC_DATA_VO_USER" ] && [[ $path =~ ^"$VSC_DATA_VO_USER"(.*)$ ]]; then
         path=\$VSC_DATA_VO_USER${BASH_REMATCH[1]}
-    elif [ "x$VSC_DATA_VO" != "x" ] && [[ $path =~ ^"$VSC_DATA_VO"(.*)$ ]]; then
+    elif [ -n "$VSC_DATA_VO" ] && [[ $path =~ ^"$VSC_DATA_VO"(.*)$ ]]; then
         path=\$VSC_DATA_VO${BASH_REMATCH[1]}
     elif [[ $path =~ ^"$VSC_DATA"(.*)$ ]]; then
         path=\$VSC_DATA${BASH_REMATCH[1]}
-    elif [ "x$VSC_SCRATCH_VO_USER" != "x" ] && [[ $path =~ ^"$VSC_SCRATCH_VO_USER"(.*)$ ]]; then
+    elif [ -n "$VSC_SCRATCH_VO_USER" ] && [[ $path =~ ^"$VSC_SCRATCH_VO_USER"(.*)$ ]]; then
         # personal scratch might be located inside a generic VO
         if [ $VSC_SCRATCH_VO_USER == $VSC_SCRATCH ];then
             path=\$VSC_SCRATCH${BASH_REMATCH[1]}
         else
             path=\$VSC_SCRATCH_VO_USER${BASH_REMATCH[1]}
         fi
-    elif [ "x$VSC_SCRATCH_VO" != "x" ] && [[ $path =~ ^"$VSC_SCRATCH_VO"(.*)$ ]]; then
+    elif [ -n "$VSC_SCRATCH_VO" ] && [[ $path =~ ^"$VSC_SCRATCH_VO"(.*)$ ]]; then
         path=\$VSC_SCRATCH_VO${BASH_REMATCH[1]}
     elif [[ $path =~ ^"$VSC_SCRATCH"(.*)$ ]]; then
         path=\$VSC_SCRATCH${BASH_REMATCH[1]}

--- a/tests/test_fixpathvsc.sh
+++ b/tests/test_fixpathvsc.sh
@@ -89,6 +89,49 @@ expectedpaths=(
 
 run_tests
 
+# overwrite environment variables for brussel user without VO
+USER=vsc10009
+VSC_INSTITUTE=brussel
+VSC_HOME=/user/brussel/100/vsc10009
+VSC_SCRATCH=/scratch/brussel/100/vsc10009
+VSC_SCRATCH_VO=""
+VSC_SCRATCH_VO_USER=""
+VSC_DATA=/data/brussel/100/vsc10009
+VSC_DATA_VO=""
+VSC_DATA_VO_USER=""
+
+origpaths=(
+    /user/brussel/100/vsc10009
+    /vscmnt/brussel_pixiu_home/_user_brussel/100/vsc10009
+    /user/brussel/100/vsc10009/testpath
+    "/user/brussel/100/vsc10009/testpath with spaces"
+    /data/brussel/100/vsc10009
+    /vscmnt/brussel_pixiu_data/_data_brussel/100/vsc10009
+    /scratch/brussel/100/vsc10009
+    /theia/scratch/brussel/100/vsc10009
+    /apps/brussel/CO7/skylake
+    /vscmnt/brussel_pixiu_apps/_apps_brussel/CO7/skylake
+    /fake/user/brussel/100/vsc10009
+    /fake/vscmnt/brussel_pixiu_home/_user_brussel/100/vsc10009
+)
+
+expectedpaths=(
+    '$VSC_HOME'
+    '$VSC_HOME'
+    '$VSC_HOME/testpath'
+    '$VSC_HOME/testpath with spaces'
+    '$VSC_DATA'
+    '$VSC_DATA'
+    '$VSC_SCRATCH'
+    '$VSC_SCRATCH'
+    /apps/brussel/CO7/skylake
+    /vscmnt/brussel_pixiu_apps/_apps_brussel/CO7/skylake
+    /fake/user/brussel/100/vsc10009
+    /fake/vscmnt/brussel_pixiu_home/_user_brussel/100/vsc10009
+)
+
+run_tests
+
 # overwrite environment variables for antwerpen user
 USER=vsc20133
 VSC_INSTITUTE=antwerpen

--- a/vsc-profiles-brussel.spec
+++ b/vsc-profiles-brussel.spec
@@ -1,6 +1,6 @@
 Summary: brussel vsc profiles files
 Name: vsc-profiles-brussel
-Version: 1.37
+Version: 1.38
 Release: 1
 License: GPL
 Group: Applications/System
@@ -42,6 +42,8 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Wed Feb 16 2023 Alex Domingo <alex.domingo.toro@vub.be>
+- Fix paths in prompt for users without VO
 * Wed Feb 15 2023 Samuel Moors <samuel.moors@vub.be>
 - Add test case for vsc prompt
 * Mon Feb 13 2023 Samuel Moors <samuel.moors@vub.be>


### PR DESCRIPTION
```shell
✔ [10:38] vsc10xxx@login1 $VSC_HOME $ cd $VSC_SCRATCH
✔ [10:38] vsc10xxx@login1 $VSC_DATA_VO_USER/scratch/brussel/101/vsc10xxx $ pwd
/scratch/brussel/101/vsc10xxx
✔ [10:38] vsc10xxx@login1 $VSC_DATA_VO_USER/scratch/brussel/101/vsc10xxx $ echo $VSC_INSTITUTE_LOCAL
brussel
✔ [10:41] vsc10xxx@login1 $VSC_DATA_VO_USER/scratch/brussel/101/vsc10xxx $ echo $VSC_INSTITUTE
brussel
✔ [10:41] vsc10xxx@login1 $VSC_DATA_VO_USER/scratch/brussel/101/vsc10xxx $ echo $VSC_SCRATCH_VO_USER

✔ [10:45] vsc10xxx@login1 $VSC_DATA_VO_USER/scratch/brussel/101/vsc10xxx $ echo $VSC_SCRATCH_VO

✔ [10:48] vsc10xxx@login1 $VSC_DATA_VO_USER/scratch/brussel/101/vsc10xxx $ echo $VSC_SCRATCH
/scratch/brussel/101/vsc10xxx
```