### PR TITLE
Avoid spurious extra colon in MODULEPATH

### DIFF
--- a/files/vsc.csh
+++ b/files/vsc.csh
@@ -2,27 +2,27 @@ eval `/usr/bin/vsc_env csh`
 
 setenv LMOD_SYSTEM_NAME "${VSC_INSTITUTE_CLUSTER}-${VSC_ARCH_LOCAL}${VSC_ARCH_SUFFIX}"
 
-setenv CLUSTER_MODULEPATH ""
+setenv CLUSTER_MODULEPATH "/etc/modulefiles/vsc"
 
 set modulesroot = "/apps/brussel/${VSC_OS_LOCAL}/${VSC_ARCH_LOCAL}${VSC_ARCH_SUFFIX}/modules"
 
 set i = 2019
 if ( -d  $modulesroot/${i}b/all ) then
-  setenv CLUSTER_MODULEPATH $modulesroot/${i}b/all:${CLUSTER_MODULEPATH}
+  setenv CLUSTER_MODULEPATH "$modulesroot/${i}b/all:${CLUSTER_MODULEPATH}"
 endif
 
 set i = 2020
 while ($i < 2025)
   if ( -d  $modulesroot/${i}a/all ) then
-    setenv CLUSTER_MODULEPATH $modulesroot/${i}a/all:${CLUSTER_MODULEPATH}
+    setenv CLUSTER_MODULEPATH "$modulesroot/${i}a/all:${CLUSTER_MODULEPATH}"
   endif
   if ( -d  $modulesroot/${i}b/all ) then
-    setenv CLUSTER_MODULEPATH $modulesroot/${i}b/all:${CLUSTER_MODULEPATH}
+    setenv CLUSTER_MODULEPATH "$modulesroot/${i}b/all:${CLUSTER_MODULEPATH}"
   endif
   @ i++
 end
 
-setenv MODULEPATH ${CLUSTER_MODULEPATH}:/etc/modulefiles/vsc
+setenv MODULEPATH "${CLUSTER_MODULEPATH}"
 
 unset CLUSTER_MODULEPATH
 

--- a/files/vsc.csh
+++ b/files/vsc.csh
@@ -2,28 +2,28 @@ eval `/usr/bin/vsc_env csh`
 
 setenv LMOD_SYSTEM_NAME "${VSC_INSTITUTE_CLUSTER}-${VSC_ARCH_LOCAL}${VSC_ARCH_SUFFIX}"
 
-setenv HYDRA_MODULEPATH ""
+setenv CLUSTER_MODULEPATH ""
 
 set modulesroot = "/apps/brussel/${VSC_OS_LOCAL}/${VSC_ARCH_LOCAL}${VSC_ARCH_SUFFIX}/modules"
 
 set i = 2019
 if ( -d  $modulesroot/${i}b/all ) then
-  setenv HYDRA_MODULEPATH $modulesroot/${i}b/all:${HYDRA_MODULEPATH}
+  setenv CLUSTER_MODULEPATH $modulesroot/${i}b/all:${CLUSTER_MODULEPATH}
 endif
 
 set i = 2020
 while ($i < 2025)
   if ( -d  $modulesroot/${i}a/all ) then
-    setenv HYDRA_MODULEPATH $modulesroot/${i}a/all:${HYDRA_MODULEPATH}
+    setenv CLUSTER_MODULEPATH $modulesroot/${i}a/all:${CLUSTER_MODULEPATH}
   endif
   if ( -d  $modulesroot/${i}b/all ) then
-    setenv HYDRA_MODULEPATH $modulesroot/${i}b/all:${HYDRA_MODULEPATH}
+    setenv CLUSTER_MODULEPATH $modulesroot/${i}b/all:${CLUSTER_MODULEPATH}
   endif
   @ i++
 end
 
-setenv MODULEPATH ${HYDRA_MODULEPATH}:/etc/modulefiles/vsc
+setenv MODULEPATH ${CLUSTER_MODULEPATH}:/etc/modulefiles/vsc
 
-unset HYDRA_MODULEPATH
+unset CLUSTER_MODULEPATH
 
 # vim: set ft=csh:

--- a/files/vsc.sh
+++ b/files/vsc.sh
@@ -2,26 +2,26 @@ eval "$(/usr/bin/vsc_env bash)"
 
 export LMOD_SYSTEM_NAME="${VSC_INSTITUTE_CLUSTER}-${VSC_ARCH_LOCAL}${VSC_ARCH_SUFFIX:-}"
 
-HYDRA_MODULEPATH=
+CLUSTER_MODULEPATH=
 
 modulesroot="/apps/brussel/${VSC_OS_LOCAL}/${VSC_ARCH_LOCAL}${VSC_ARCH_SUFFIX:-}/modules"
 
 i=2019
 if [ -d "$modulesroot/${i}b/all" ]; then
-  HYDRA_MODULEPATH=$modulesroot/${i}b/all:$HYDRA_MODULEPATH
+  CLUSTER_MODULEPATH=$modulesroot/${i}b/all:$CLUSTER_MODULEPATH
 fi
 
 for i in {2020..2025}; do
   if [ -d "$modulesroot/${i}a/all" ]; then
-    HYDRA_MODULEPATH=$modulesroot/${i}a/all:$HYDRA_MODULEPATH
+    CLUSTER_MODULEPATH=$modulesroot/${i}a/all:$CLUSTER_MODULEPATH
   fi
   if [ -d "$modulesroot/${i}b/all" ]; then
-    HYDRA_MODULEPATH=$modulesroot/${i}b/all:$HYDRA_MODULEPATH
+    CLUSTER_MODULEPATH=$modulesroot/${i}b/all:$CLUSTER_MODULEPATH
   fi
 done
 
-export MODULEPATH=$HYDRA_MODULEPATH:/etc/modulefiles/vsc
+export MODULEPATH=$CLUSTER_MODULEPATH:/etc/modulefiles/vsc
 
-unset HYDRA_MODULEPATH
+unset CLUSTER_MODULEPATH
 
 # vim: set ft=sh:

--- a/files/vsc.sh
+++ b/files/vsc.sh
@@ -2,25 +2,25 @@ eval "$(/usr/bin/vsc_env bash)"
 
 export LMOD_SYSTEM_NAME="${VSC_INSTITUTE_CLUSTER}-${VSC_ARCH_LOCAL}${VSC_ARCH_SUFFIX:-}"
 
-CLUSTER_MODULEPATH=
+CLUSTER_MODULEPATH="/etc/modulefiles/vsc"
 
 modulesroot="/apps/brussel/${VSC_OS_LOCAL}/${VSC_ARCH_LOCAL}${VSC_ARCH_SUFFIX:-}/modules"
 
 i=2019
 if [ -d "$modulesroot/${i}b/all" ]; then
-  CLUSTER_MODULEPATH=$modulesroot/${i}b/all:$CLUSTER_MODULEPATH
+  CLUSTER_MODULEPATH="$modulesroot/${i}b/all:$CLUSTER_MODULEPATH"
 fi
 
 for i in {2020..2025}; do
   if [ -d "$modulesroot/${i}a/all" ]; then
-    CLUSTER_MODULEPATH=$modulesroot/${i}a/all:$CLUSTER_MODULEPATH
+    CLUSTER_MODULEPATH="$modulesroot/${i}a/all:$CLUSTER_MODULEPATH"
   fi
   if [ -d "$modulesroot/${i}b/all" ]; then
-    CLUSTER_MODULEPATH=$modulesroot/${i}b/all:$CLUSTER_MODULEPATH
+    CLUSTER_MODULEPATH="$modulesroot/${i}b/all:$CLUSTER_MODULEPATH"
   fi
 done
 
-export MODULEPATH=$CLUSTER_MODULEPATH:/etc/modulefiles/vsc
+export MODULEPATH="$CLUSTER_MODULEPATH"
 
 unset CLUSTER_MODULEPATH
 

--- a/vsc-profiles-brussel.spec
+++ b/vsc-profiles-brussel.spec
@@ -1,6 +1,6 @@
 Summary: brussel vsc profiles files
 Name: vsc-profiles-brussel
-Version: 1.39
+Version: 1.40
 Release: 1
 License: GPL
 Group: Applications/System
@@ -42,6 +42,8 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Fri Sep 29 2023 Alex Domingo <alex.domingo.toro@vub.be>
+- Avoid spurious extra colon in MODULEPATH
 * Mon Mar 27 2023 Samuel Moors <samuel.moors@vub.be>
 - Restrict MODULEPATH to the more recent ones
 * Wed Feb 16 2023 Alex Domingo <alex.domingo.toro@vub.be>


### PR DESCRIPTION
3 minor changes:
* prepend over staple path to avoid spurious colons in MODULEPATH
* rename `HYDRA_MODULEPATH` to more generic `CLUSTER_MODULEPATH`
* protect assignments with quotes