### PR TITLE
update vsc prompt for sofia

### DIFF
--- a/files/vscprompt.sh
+++ b/files/vscprompt.sh
@@ -15,7 +15,11 @@ fixpathvsc(){
     fi
 
     # convert canonical paths to environment variable
-    if [[ $path =~ ^"$VSC_HOME"(.*)$ ]]; then
+    if [[ $path =~ ^/user/sofia/$USER(.*)$ ]]; then
+        path=\$HOME${BASH_REMATCH[1]}
+    elif [ -n "$VSC_SCRATCH_PROJECTS_BASE" ] && [[ $path =~ ^"$VSC_SCRATCH_PROJECTS_BASE"(.*)$ ]]; then
+        path=\$VSC_SCRATCH_PROJECTS_BASE${BASH_REMATCH[1]}
+    elif [[ $path =~ ^"$VSC_HOME"(.*)$ ]]; then
         path=\$VSC_HOME${BASH_REMATCH[1]}
     elif [ -n "$VSC_DATA_VO_USER" ] && [[ $path =~ ^"$VSC_DATA_VO_USER"(.*)$ ]]; then
         path=\$VSC_DATA_VO_USER${BASH_REMATCH[1]}

--- a/tests/test_fixpathvsc.sh
+++ b/tests/test_fixpathvsc.sh
@@ -43,6 +43,7 @@ USER=vsc10009
 VSC_INSTITUTE=brussel
 VSC_HOME=/user/brussel/100/vsc10009
 VSC_SCRATCH=/scratch/brussel/100/vsc10009
+VSC_SCRATCH_PROJECTS_BASE=/sofia/projects
 VSC_SCRATCH_VO=/scratch/brussel/vo/000/bvo00005
 VSC_SCRATCH_VO_USER=$VSC_SCRATCH_VO/$USER
 VSC_DATA=/data/brussel/100/vsc10009
@@ -67,6 +68,11 @@ origpaths=(
     /fake/user/brussel/100/vsc10009
     /fake/vscmnt/brussel_pixiu_home/_user_brussel/100/vsc10009
     /rhea/scratch/brussel/100/vsc10009
+    /user/sofia/vsc10009
+    /user/sofia/vsc10009/testpath
+    /sofia/projects
+    /sofia/projects/someproject
+    /sofia/scratch/pilot/badmin
 )
 
 expectedpaths=(
@@ -87,6 +93,11 @@ expectedpaths=(
     /fake/user/brussel/100/vsc10009
     /fake/vscmnt/brussel_pixiu_home/_user_brussel/100/vsc10009
     '$VSC_SCRATCH'
+    '$HOME'
+    '$HOME/testpath'
+    '$VSC_SCRATCH_PROJECTS_BASE'
+    '$VSC_SCRATCH_PROJECTS_BASE/someproject'
+    /sofia/scratch/pilot/badmin
 )
 
 run_tests

--- a/tests/test_fixpathvsc.sh
+++ b/tests/test_fixpathvsc.sh
@@ -43,7 +43,7 @@ USER=vsc10009
 VSC_INSTITUTE=brussel
 VSC_HOME=/user/brussel/100/vsc10009
 VSC_SCRATCH=/scratch/brussel/100/vsc10009
-VSC_SCRATCH_PROJECTS_BASE=/sofia/projects
+VSC_SCRATCH_PROJECTS_BASE=/sofia/scratch/projects
 VSC_SCRATCH_VO=/scratch/brussel/vo/000/bvo00005
 VSC_SCRATCH_VO_USER=$VSC_SCRATCH_VO/$USER
 VSC_DATA=/data/brussel/100/vsc10009
@@ -70,8 +70,8 @@ origpaths=(
     /rhea/scratch/brussel/100/vsc10009
     /user/sofia/vsc10009
     /user/sofia/vsc10009/testpath
-    /sofia/projects
-    /sofia/projects/someproject
+    /sofia/scratch/projects
+    /sofia/scratch/projects/someproject
     /sofia/scratch/pilot/badmin
 )
 

--- a/vsc-profiles-brussel.spec
+++ b/vsc-profiles-brussel.spec
@@ -1,6 +1,6 @@
 Summary: brussel vsc profiles files
 Name: vsc-profiles-brussel
-Version: 1.45
+Version: 1.46
 Release: 1
 License: GPL
 Group: Applications/System
@@ -42,6 +42,8 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Thu Apr 23 2026 Samuel Moors <samuel.moors@vub.be>
+- Update vsc prompt for sofia
 * Mon Apr 20 2026 Alex Domingo <alex.domingo.toro@vub.be>
 - Ensure permissions of ~/.ssh directory on creation
 * Thu Apr 09 2026 Alex Domingo <alex.domingo.toro@vub.be>


### PR DESCRIPTION
i didn't add a special prompt for the pilot paths, because there is no environment variable available for it, so better to use the full path.

[AB#29844](https://dev.azure.com/VUB-ICT/3e951b95-f932-4cd3-9681-259422e2c681/_workitems/edit/29844)